### PR TITLE
feat(responsive): add mobile-friendly clamps, disable parallax on small screens, stack CTAs, add failsafes

### DIFF
--- a/client/src/components/ui/HeroFX.tsx
+++ b/client/src/components/ui/HeroFX.tsx
@@ -17,6 +17,18 @@ export default function HeroFX({
     anchor: React.RefObject<HTMLElement>;
     parallax?: number;
 }) {
+    const reduce =
+        typeof window !== "undefined" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const small =
+        typeof window !== "undefined" &&
+        window.matchMedia("(max-width: 640px)").matches;
+
+    if (reduce || small) {
+        return (
+            <div className="fixed inset-0 pointer-events-none z-0 bg-gradient-to-br from-purple-900/40 via-sky-900/20 to-purple-900/40" />
+        );
+    }
     /* ── create once ─────────────────────────────────────────────────────── */
     const mount = useRef<HTMLDivElement | null>(null);
     if (!mount.current) {
@@ -62,6 +74,7 @@ export default function HeroFX({
 
     /* ── 3. parallax shift on pointermove (optional) ───────────────────────── */
     useEffect(() => {
+        if (reduce || small) return;
         const layer = mount.current!;
         const move  = (e: MouseEvent) => {
             const { innerWidth:w, innerHeight:h } = window;
@@ -71,7 +84,7 @@ export default function HeroFX({
         };
         window.addEventListener("pointermove", move);
         return () => window.removeEventListener("pointermove", move);
-    }, [parallax]);
+    }, [parallax, reduce, small]);
 
     /* ── render ThreeBurst into the portal ─────────────────────────────────── */
     return createPortal(<ThreeBurst />, mount.current);

--- a/client/src/components/ui/ThreeBurst.tsx
+++ b/client/src/components/ui/ThreeBurst.tsx
@@ -151,6 +151,16 @@ function Effects() {
    Main export
 ────────────────────────────────────────────────────────────── */
 export default function ThreeBurst() {
+    const reduce =
+        typeof window !== "undefined" &&
+        window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const small =
+        typeof window !== "undefined" &&
+        window.matchMedia("(max-width: 640px)").matches;
+    if (reduce || small) {
+        return null;
+    }
+
     /* cap DPR to 2 for perf; still retina-ish */
     const [dpr] = useState(() => Math.min(window.devicePixelRatio, 2));
 

--- a/client/src/pages/Index.tsx
+++ b/client/src/pages/Index.tsx
@@ -35,7 +35,9 @@ const dots = [
 /* — tilt utility — */
 function useTilt(el: React.RefObject<HTMLElement>, max = 15) {
     useEffect(() => {
-        if (matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+        const reduce = matchMedia("(prefers-reduced-motion: reduce)").matches;
+        const small  = matchMedia("(max-width: 640px)").matches;
+        if (reduce || small) return;
         const onScroll = () => {
             if (!el.current) return;
             const { top } = el.current.getBoundingClientRect();
@@ -106,12 +108,14 @@ export default function Index() {
                     <header ref={heroTxt} className="will-change-transform motion-reduce:transform-none">
                         <h1
                             id="hero-heading"
-                            className="text-[2.8rem] sm:text-6xl md:text-7xl lg:text-8xl
-                         font-extrabold leading-tight tracking-tight
+                            className="font-extrabold leading-tight tracking-tight
                          bg-gradient-to-r from-white via-gray-100 to-white
                          bg-clip-text text-transparent
                          drop-shadow-[0_8px_30px_rgba(0,0,0,0.6)]"
-                            style={{ WebkitTextStroke: "1px rgba(255,255,255,0.12)" }}
+                            style={{
+                                fontSize: "clamp(2.4rem,8vw,6rem)",
+                                WebkitTextStroke: "1px rgba(255,255,255,0.12)",
+                            }}
                         >
                             Craft&nbsp;Your&nbsp;Digital
                             <br />
@@ -132,7 +136,8 @@ export default function Index() {
 
                     {/* CTA glass-bar */}
                     <div
-                        className="relative mx-auto flex w-max gap-6 px-10 py-6 rounded-full
+                        className="relative mx-auto flex flex-col xs:flex-row w-full xs:w-max
+                       gap-4 xs:gap-6 px-6 xs:px-10 py-6 rounded-full
                        bg-white/5 backdrop-blur-md border border-white/10
                        shadow-[0_12px_45px_rgba(0,0,0,0.35)]
                        after:absolute after:inset-0 after:rounded-full

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -4,6 +4,10 @@ export default {
   darkMode: ["class"],
   content: ["./client/index.html", "./client/src/**/*.{js,jsx,ts,tsx}"],
   theme: {
+    screens: {
+      xxs: "320px",
+      xs: "480px",
+    },
     extend: {
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
- clamp hero font-size to avoid overflow
- stack CTA buttons vertically on small screens
- disable HeroFX parallax on small devices or reduced motion
- skip ThreeBurst on small devices and motion-reduced setting
- add extra small screen breakpoints to Tailwind

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e935c9250833397b6f76ff9e42559